### PR TITLE
Added clear information about content-policy for development.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ Using Firebase in an Extension
 ------------------------------
 The key to using Firebase in a Chrome extension is adding the following content security policy to your manifest.json:
 
+for development:
+
+```json
+{
+  "content_security_policy": "script-src 'self' https://cdn.firebase.com https://*.firebaseio.com https://*.firebaseio-demo.com; object-src 'self'",
+}
+```
+
+for production:
+
 ```json
 {
   "content_security_policy": "script-src 'self' https://cdn.firebase.com https://*.firebaseio.com; object-src 'self'"


### PR DESCRIPTION
During development of my plugin which uses firebase I encountered problem with CORS but thankfully I found this repository. I thought that `content-policy` in readme should work in my plugin but it didn't. I found the longer one, with firebase development servers (`firebaseio-demo.com`) in source code of the plugin. I think that having it directly in readme is clearer for someone searching only for that particular information.
